### PR TITLE
Addressing ambiguous parameterization of angle value range and angle increment

### DIFF
--- a/include/pointcloud_to_laserscan/pointcloud_to_laserscan_nodelet.h
+++ b/include/pointcloud_to_laserscan/pointcloud_to_laserscan_nodelet.h
@@ -76,6 +76,8 @@ namespace pointcloud_to_laserscan
 
     void disconnectCb();
 
+    void adjust_angle_configuration();
+
     ros::NodeHandle nh_, private_nh_;
     ros::Publisher pub_;
     boost::mutex connect_mutex_;
@@ -90,6 +92,8 @@ namespace pointcloud_to_laserscan
     std::string target_frame_;
     double tolerance_;
     double min_height_, max_height_, angle_min_, angle_max_, angle_increment_, scan_time_, range_min_, range_max_;
+    double angle_lower_bound_, angle_upper_bound_;
+    int ranges_size_;
     bool use_inf_;
     double inf_epsilon_;
   };


### PR DESCRIPTION
I adjusted the angle handling code a bit, and added another optional parameter to directly specify the number of bins instead of computing it via the bin width parameter (angle_increment).

The changes change the behavior of the output in subtle ways. It seems to work on my machine, but I didn't thoroughly test it. Feel free to review and merge whatever bits you like.