### PR TITLE
change files to compile with melodic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(pointcloud_to_laserscan)
 
+## Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-Wall -Wno-psabi -Wextra)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 find_package(catkin REQUIRED COMPONENTS
   laser_geometry
   message_filters


### PR DESCRIPTION
I am on ROS melodic-devel, while I clone lunar-devel branch and catkin_make it; it shows up many C++ compiling bugs. 
I solved by adding C++11 compiling setup on CMakelist, C++ 11 supported in ROS Kinetic and newer. 

I am prefer to merge with melodic-devel branch, but you don't have it. So I pull request on your lunar-devel, I guess both works :).  