### PR TITLE
Make cloud and scan topic names parameterizable

### DIFF
--- a/include/pointcloud_to_laserscan/laserscan_to_pointcloud_node.hpp
+++ b/include/pointcloud_to_laserscan/laserscan_to_pointcloud_node.hpp
@@ -91,6 +91,8 @@ private:
   int input_queue_size_;
   std::string target_frame_;
   double tolerance_;
+  std::string point_cloud_topic_;
+  std::string scan_topic_;
 };
 
 }  // namespace pointcloud_to_laserscan

--- a/include/pointcloud_to_laserscan/pointcloud_to_laserscan_node.hpp
+++ b/include/pointcloud_to_laserscan/pointcloud_to_laserscan_node.hpp
@@ -95,6 +95,8 @@ private:
     range_max_;
   bool use_inf_;
   double inf_epsilon_;
+  std::string point_cloud_topic_;
+  std::string scan_topic_;
 };
 
 }  // namespace pointcloud_to_laserscan

--- a/src/laserscan_to_pointcloud_node.cpp
+++ b/src/laserscan_to_pointcloud_node.cpp
@@ -60,12 +60,15 @@ LaserScanToPointCloudNode::LaserScanToPointCloudNode(const rclcpp::NodeOptions &
 {
   target_frame_ = this->declare_parameter("target_frame", "");
   tolerance_ = this->declare_parameter("transform_tolerance", 0.01);
+  point_cloud_topic_ = this->declare_parameter("point_cloud_topic", "cloud");
+  scan_topic_ = this->declare_parameter("scan_topic", "scan_in");
   // TODO(hidmic): adjust default input queue size based on actual concurrency levels
   // achievable by the associated executor
   input_queue_size_ = this->declare_parameter(
     "queue_size", static_cast<int>(std::thread::hardware_concurrency()));
 
-  pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("cloud", rclcpp::SensorDataQoS());
+  pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(
+    point_cloud_topic_, rclcpp::SensorDataQoS());
 
   using std::placeholders::_1;
   // if pointcloud target frame specified, we need to filter by transform availability
@@ -111,7 +114,7 @@ void LaserScanToPointCloudNode::subscriptionListenerThreadLoop()
           "Got a subscriber to pointcloud, starting laserscan subscriber");
         rclcpp::SensorDataQoS qos;
         qos.keep_last(input_queue_size_);
-        sub_.subscribe(this, "scan_in", qos.get_rmw_qos_profile());
+        sub_.subscribe(this, scan_topic_, qos.get_rmw_qos_profile());
       }
     } else if (sub_.getSubscriber()) {
       RCLCPP_INFO(

--- a/src/pointcloud_to_laserscan_node.cpp
+++ b/src/pointcloud_to_laserscan_node.cpp
@@ -74,8 +74,10 @@ PointCloudToLaserScanNode::PointCloudToLaserScanNode(const rclcpp::NodeOptions &
   range_max_ = this->declare_parameter("range_max", std::numeric_limits<double>::max());
   inf_epsilon_ = this->declare_parameter("inf_epsilon", 1.0);
   use_inf_ = this->declare_parameter("use_inf", true);
+  point_cloud_topic_ = this->declare_parameter("point_cloud_topic", "cloud_in");
+  scan_topic_ = this->declare_parameter("scan_topic", "scan");
 
-  pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>("scan", rclcpp::SensorDataQoS());
+  pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>(scan_topic_, rclcpp::SensorDataQoS());
 
   using std::placeholders::_1;
   // if pointcloud target frame specified, we need to filter by transform availability
@@ -120,7 +122,7 @@ void PointCloudToLaserScanNode::subscriptionListenerThreadLoop()
           "Got a subscriber to laserscan, starting pointcloud subscriber");
         rclcpp::SensorDataQoS qos;
         qos.keep_last(input_queue_size_);
-        sub_.subscribe(this, "cloud_in", qos.get_rmw_qos_profile());
+        sub_.subscribe(this, point_cloud_topic_, qos.get_rmw_qos_profile());
       }
     } else if (sub_.getSubscriber()) {
       RCLCPP_INFO(


### PR DESCRIPTION
Feel like it is convenient to be able to change topic names it subscribes or publishes to. In my specific situation, the only option in launch files to have the node converts my scan data named "filtered_scan" to a point cloud was by remapping. But I can't use LaunchConfigurations in the remap list, while I can use it in the RewrittenYaml class from nav2_utils, to rewrite parameters conditionally to the launch file instead of having them fixed by the parameter file.

All in all, it is adding the option to change topic names and is not removing anything.