### PR TITLE
Fix default parameters in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ This ROS 2 component projects `sensor_msgs/msg/PointCloud2` messages into `senso
 
 ### Parameters
 
-* `min_height` (double, default: 0.0) - The minimum height to sample in the point cloud in meters.
-* `max_height` (double, default: inf) - The maximum height to sample in the point cloud in meters.
+* `min_height` (double, default: 2.2e-308) - The minimum height to sample in the point cloud in meters.
+* `max_height` (double, default: 1.8e+308) - The maximum height to sample in the point cloud in meters.
 * `angle_min` (double, default: -π) - The minimum scan angle in radians.
 * `angle_max` (double, default: π) - The maximum scan angle in radians.
-* `angle_increment` (double, default: π/360) - Resolution of laser scan in radians per ray.
+* `angle_increment` (double, default: π/180) - Resolution of laser scan in radians per ray.
 * `queue_size` (double, default: detected number of cores) - Input point cloud queue size.
 * `scan_time` (double, default: 1.0/30.0) - The scan rate in seconds. Only used to populate the scan_time field of the output laser scan message.
 * `range_min` (double, default: 0.0) - The minimum ranges to return in meters.
-* `range_max` (double, default: inf) - The maximum ranges to return in meters.
+* `range_max` (double, default: 1.8e+308) - The maximum ranges to return in meters.
 * `target_frame` (str, default: none) - If provided, transform the pointcloud into this frame before converting to a laser scan. Otherwise, laser scan will be generated in the same frame as the input point cloud.
 * `transform_tolerance` (double, default: 0.01) - Time tolerance for transform lookups. Only used if a `target_frame` is provided.
 * `use_inf` (boolean, default: true) - If disabled, report infinite range (no obstacle) as range_max + 1. Otherwise report infinite range as +inf.
@@ -47,4 +47,3 @@ This ROS 2 component re-publishes `sensor_msgs/msg/LaserScan` messages as `senso
 * `queue_size` (double, default: detected number of cores) - Input laser scan queue size.
 * `target_frame` (str, default: none) - If provided, transform the pointcloud into this frame before converting to a laser scan. Otherwise, laser scan will be generated in the same frame as the input point cloud.
 * `transform_tolerance` (double, default: 0.01) - Time tolerance for transform lookups. Only used if a `target_frame` is provided.
-* `use_inf` (boolean, default: true) - If disabled, report infinite range (no obstacle) as range_max + 1. Otherwise report infinite range as +inf.

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ This ROS 2 component projects `sensor_msgs/msg/PointCloud2` messages into `senso
 ### Parameters
 
 * `min_height` (double, default: 0.0) - The minimum height to sample in the point cloud in meters.
-* `max_height` (double, default: 1.0) - The maximum height to sample in the point cloud in meters.
-* `angle_min` (double, default: -π/2) - The minimum scan angle in radians.
-* `angle_max` (double, default: π/2) - The maximum scan angle in radians.
+* `max_height` (double, default: inf) - The maximum height to sample in the point cloud in meters.
+* `angle_min` (double, default: -π) - The minimum scan angle in radians.
+* `angle_max` (double, default: π) - The maximum scan angle in radians.
 * `angle_increment` (double, default: π/360) - Resolution of laser scan in radians per ray.
 * `queue_size` (double, default: detected number of cores) - Input point cloud queue size.
 * `scan_time` (double, default: 1.0/30.0) - The scan rate in seconds. Only used to populate the scan_time field of the output laser scan message.
-* `range_min` (double, default: 0.45) - The minimum ranges to return in meters.
-* `range_max` (double, default: 4.0) - The maximum ranges to return in meters.
+* `range_min` (double, default: 0.0) - The minimum ranges to return in meters.
+* `range_max` (double, default: inf) - The maximum ranges to return in meters.
 * `target_frame` (str, default: none) - If provided, transform the pointcloud into this frame before converting to a laser scan. Otherwise, laser scan will be generated in the same frame as the input point cloud.
 * `transform_tolerance` (double, default: 0.01) - Time tolerance for transform lookups. Only used if a `target_frame` is provided.
 * `use_inf` (boolean, default: true) - If disabled, report infinite range (no obstacle) as range_max + 1. Otherwise report infinite range as +inf.


### PR DESCRIPTION
Some default parameters in the README file are wrong after looking at the source code https://github.com/ros-perception/pointcloud_to_laserscan/blob/rolling/src/pointcloud_to_laserscan_node.cpp#L58