### PR TITLE
Increase the range of available min & max angle.

### DIFF
--- a/src/pointcloud_to_laserscan_nodelet.cpp
+++ b/src/pointcloud_to_laserscan_nodelet.cpp
@@ -195,7 +195,7 @@ void PointCloudToLaserScanNodelet::cloudCb(const sensor_msgs::PointCloud2ConstPt
     cloud_out = cloud_msg;
   }
 
-  int n=0;
+  int n = 0;
   // Iterate through pointcloud
   for (sensor_msgs::PointCloud2ConstIterator<float> iter_x(*cloud_out, "x"), iter_y(*cloud_out, "y"),
        iter_z(*cloud_out, "z");
@@ -235,7 +235,8 @@ void PointCloudToLaserScanNodelet::cloudCb(const sensor_msgs::PointCloud2ConstPt
       ++n;
       angle = angle_origin + n * 2 * M_PI;
     }
-    if(angle <= output.angle_max){
+    if (angle <= output.angle_max)
+    {
       // overwrite range at laserscan ray if new range is smaller
       int index = (angle - output.angle_min) / output.angle_increment;
       if (range < output.ranges[index])
@@ -243,12 +244,16 @@ void PointCloudToLaserScanNodelet::cloudCb(const sensor_msgs::PointCloud2ConstPt
         output.ranges[index] = range;
       }
       continue;
-    }else{
-      while(angle > output.angle_max){
+    }
+    else
+    {
+      while (angle > output.angle_max)
+      {
         --n;
         angle = angle_origin + n * 2 * M_PI;
       }
-      if(angle>=output.angle_min){
+      if (angle >= output.angle_min)
+      {
         // overwrite range at laserscan ray if new range is smaller
         int index = (angle - output.angle_min) / output.angle_increment;
         if (range < output.ranges[index])
@@ -258,7 +263,6 @@ void PointCloudToLaserScanNodelet::cloudCb(const sensor_msgs::PointCloud2ConstPt
         continue;
       }
     }
-    
     NODELET_DEBUG("rejected for angle %f not in range (%f, %f)\n", angle, output.angle_min, output.angle_max);
   }
 


### PR DESCRIPTION
Thank you for this very convenient and helpful plugin. However, there is a problem of data loss when the output.max and output.min are out of the range -π to π because the result of function std::atan2 is between -π to π. I have made some simple modifications to make it suitable for any desired angle.

This code has been tested under the PX4 Collision Prevention module where (0,2π) is needed.