### PR TITLE
resolved rmw_qos_profile_t to rclcpp::QoS and changed message_filters/subscriber .h to .hpp

### DIFF
--- a/include/pointcloud_to_laserscan/laserscan_to_pointcloud_node.hpp
+++ b/include/pointcloud_to_laserscan/laserscan_to_pointcloud_node.hpp
@@ -46,12 +46,12 @@
 #include <string>
 #include <thread>
 
-#include "message_filters/subscriber.h"
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/message_filter.h"
 #include "tf2_ros/transform_listener.h"
 
 #include "laser_geometry/laser_geometry.hpp"
+#include "message_filters/subscriber.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/laser_scan.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"

--- a/include/pointcloud_to_laserscan/pointcloud_to_laserscan_node.hpp
+++ b/include/pointcloud_to_laserscan/pointcloud_to_laserscan_node.hpp
@@ -46,11 +46,11 @@
 #include <string>
 #include <thread>
 
-#include "message_filters/subscriber.h"
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/message_filter.h"
 #include "tf2_ros/transform_listener.h"
 
+#include "message_filters/subscriber.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/laser_scan.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"

--- a/src/laserscan_to_pointcloud_node.cpp
+++ b/src/laserscan_to_pointcloud_node.cpp
@@ -111,7 +111,7 @@ void LaserScanToPointCloudNode::subscriptionListenerThreadLoop()
           "Got a subscriber to pointcloud, starting laserscan subscriber");
         rclcpp::SensorDataQoS qos;
         qos.keep_last(input_queue_size_);
-        sub_.subscribe(this, "scan_in", qos.get_rmw_qos_profile());
+        sub_.subscribe(this, "scan_in", qos);
       }
     } else if (sub_.getSubscriber()) {
       RCLCPP_INFO(

--- a/src/pointcloud_to_laserscan_node.cpp
+++ b/src/pointcloud_to_laserscan_node.cpp
@@ -120,7 +120,7 @@ void PointCloudToLaserScanNode::subscriptionListenerThreadLoop()
           "Got a subscriber to laserscan, starting pointcloud subscriber");
         rclcpp::SensorDataQoS qos;
         qos.keep_last(input_queue_size_);
-        sub_.subscribe(this, "cloud_in", qos.get_rmw_qos_profile());
+        sub_.subscribe(this, "cloud_in", qos);
       }
     } else if (sub_.getSubscriber()) {
       RCLCPP_INFO(


### PR DESCRIPTION
**IMPORTANT NOTICE** : merging this PR will make jazzy build failure. I found that rolling branch is being use for both jazzy and rolling in ROS index. The following changes are to make rolling version workable.

resolved rmw_qos_profile_t to rclcpp::QoS : To comply with message_filters package
changed message_filters/subscriber .h to .hpp: replaced obsoleted header