### PR TITLE
Filter out points in a bounding box

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ This ROS 2 component projects `sensor_msgs/msg/PointCloud2` messages into `senso
 * `angle_min` (double, default: -π) - The minimum scan angle in radians.
 * `angle_max` (double, default: π) - The maximum scan angle in radians.
 * `angle_increment` (double, default: π/180) - Resolution of laser scan in radians per ray.
+* `exclude_within_x` (double tuple, default: [0.0, 0.0]) - Boundaries of the exclusion box along x
+* `exclude_within_y` (double tuple, default: [0.0, 0.0]) - Boundaries of the exclusion box along y
+* `exclude_within_z` (double tuple, default: [0.0, 0.0]) - Boundaries of the exclusion box along z
 * `queue_size` (double, default: detected number of cores) - Input point cloud queue size.
 * `scan_time` (double, default: 1.0/30.0) - The scan rate in seconds. Only used to populate the scan_time field of the output laser scan message.
 * `range_min` (double, default: 0.0) - The minimum ranges to return in meters.

--- a/include/pointcloud_to_laserscan/pointcloud_to_laserscan_node.hpp
+++ b/include/pointcloud_to_laserscan/pointcloud_to_laserscan_node.hpp
@@ -92,7 +92,8 @@ private:
   std::string target_frame_;
   double tolerance_;
   double min_height_, max_height_, angle_min_, angle_max_, angle_increment_, scan_time_, range_min_,
-    range_max_;
+    range_max_, exclusion_box_min_x_, exclusion_box_max_x_, exclusion_box_min_y_, exclusion_box_max_y_,
+    exclusion_box_min_z_, exclusion_box_max_z_;
   bool use_inf_;
   double inf_epsilon_;
 };

--- a/include/pointcloud_to_laserscan/pointcloud_to_laserscan_node.hpp
+++ b/include/pointcloud_to_laserscan/pointcloud_to_laserscan_node.hpp
@@ -92,8 +92,8 @@ private:
   std::string target_frame_;
   double tolerance_;
   double min_height_, max_height_, angle_min_, angle_max_, angle_increment_, scan_time_, range_min_,
-    range_max_, exclusion_box_min_x_, exclusion_box_max_x_, exclusion_box_min_y_, exclusion_box_max_y_,
-    exclusion_box_min_z_, exclusion_box_max_z_;
+    range_max_, exclusion_box_min_x_, exclusion_box_max_x_, exclusion_box_min_y_,
+    exclusion_box_max_y_, exclusion_box_min_z_, exclusion_box_max_z_;
   bool use_inf_;
   double inf_epsilon_;
 };

--- a/src/pointcloud_to_laserscan_node.cpp
+++ b/src/pointcloud_to_laserscan_node.cpp
@@ -75,6 +75,17 @@ PointCloudToLaserScanNode::PointCloudToLaserScanNode(const rclcpp::NodeOptions &
   inf_epsilon_ = this->declare_parameter("inf_epsilon", 1.0);
   use_inf_ = this->declare_parameter("use_inf", true);
 
+  auto exclusion_box_x_param_ = this->declare_parameter<std::vector<double>>("exclude_within_x", {0.0, 0.0});
+  auto exclusion_box_y_param_ = this->declare_parameter<std::vector<double>>("exclude_within_y", {0.0, 0.0});
+  auto exclusion_box_z_param_ = this->declare_parameter<std::vector<double>>("exclude_within_z", {0.0, 0.0});
+
+  exclusion_box_min_x_ = exclusion_box_x_param_[0];
+  exclusion_box_max_x_ = exclusion_box_x_param_[1];
+  exclusion_box_min_y_ = exclusion_box_y_param_[0];
+  exclusion_box_max_y_ = exclusion_box_y_param_[1];
+  exclusion_box_min_z_ = exclusion_box_z_param_[0];
+  exclusion_box_max_z_ = exclusion_box_z_param_[1];
+
   pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>("scan", rclcpp::SensorDataQoS());
 
   using std::placeholders::_1;
@@ -193,6 +204,17 @@ void PointCloudToLaserScanNode::cloudCallback(
         this->get_logger(),
         "rejected for height %f not in range (%f, %f)\n",
         *iter_z, min_height_, max_height_);
+      continue;
+    }
+
+    if ((*iter_x > exclusion_box_min_x_ && *iter_x < exclusion_box_max_x_) &&
+      (*iter_y > exclusion_box_min_y_ && *iter_y < exclusion_box_max_y_) &&
+      (*iter_z > exclusion_box_min_z_ && *iter_z < exclusion_box_max_z_)) {
+      RCLCPP_DEBUG(
+        this->get_logger(),
+        "rejected for point (%f, %f, %f) being in the exclusion region x: (%f, %f) y: (%f, %f), z: (%f, %f)\n",
+        *iter_x, *iter_y, *iter_z, exclusion_box_min_x_, exclusion_box_max_x_, exclusion_box_min_y_,
+        exclusion_box_max_y_, exclusion_box_min_z_, exclusion_box_max_z_);
       continue;
     }
 

--- a/src/pointcloud_to_laserscan_node.cpp
+++ b/src/pointcloud_to_laserscan_node.cpp
@@ -79,12 +79,26 @@ PointCloudToLaserScanNode::PointCloudToLaserScanNode(const rclcpp::NodeOptions &
   auto exclusion_box_y_param_ = this->declare_parameter<std::vector<double>>("exclude_within_y", {0.0, 0.0});
   auto exclusion_box_z_param_ = this->declare_parameter<std::vector<double>>("exclude_within_z", {0.0, 0.0});
 
-  exclusion_box_min_x_ = exclusion_box_x_param_[0];
-  exclusion_box_max_x_ = exclusion_box_x_param_[1];
-  exclusion_box_min_y_ = exclusion_box_y_param_[0];
-  exclusion_box_max_y_ = exclusion_box_y_param_[1];
-  exclusion_box_min_z_ = exclusion_box_z_param_[0];
-  exclusion_box_max_z_ = exclusion_box_z_param_[1];
+  if ((exclusion_box_x_param_[1] >= exclusion_box_x_param_[0]) &&
+    (exclusion_box_y_param_[1] >= exclusion_box_y_param_[0]) &&
+    (exclusion_box_z_param_[1] >= exclusion_box_z_param_[0]))
+  {
+    exclusion_box_min_x_ = exclusion_box_x_param_[0];
+    exclusion_box_max_x_ = exclusion_box_x_param_[1];
+    exclusion_box_min_y_ = exclusion_box_y_param_[0];
+    exclusion_box_max_y_ = exclusion_box_y_param_[1];
+    exclusion_box_min_z_ = exclusion_box_z_param_[0];
+    exclusion_box_max_z_ = exclusion_box_z_param_[1];
+  }
+  else
+  {
+    exclusion_box_min_x_ = 0.0;
+    exclusion_box_max_x_ = 0.0;
+    exclusion_box_min_y_ = 0.0;
+    exclusion_box_max_y_ = 0.0;
+    exclusion_box_min_z_ = 0.0;
+    exclusion_box_max_z_ = 0.0;
+  }
 
   pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>("scan", rclcpp::SensorDataQoS());
 

--- a/src/pointcloud_to_laserscan_node.cpp
+++ b/src/pointcloud_to_laserscan_node.cpp
@@ -75,9 +75,12 @@ PointCloudToLaserScanNode::PointCloudToLaserScanNode(const rclcpp::NodeOptions &
   inf_epsilon_ = this->declare_parameter("inf_epsilon", 1.0);
   use_inf_ = this->declare_parameter("use_inf", true);
 
-  auto exclusion_box_x_param_ = this->declare_parameter<std::vector<double>>("exclude_within_x", {0.0, 0.0});
-  auto exclusion_box_y_param_ = this->declare_parameter<std::vector<double>>("exclude_within_y", {0.0, 0.0});
-  auto exclusion_box_z_param_ = this->declare_parameter<std::vector<double>>("exclude_within_z", {0.0, 0.0});
+  auto exclusion_box_x_param_ = this->declare_parameter<std::vector<double>>(
+    "exclude_within_x", {0.0, 0.0});
+  auto exclusion_box_y_param_ = this->declare_parameter<std::vector<double>>(
+    "exclude_within_y", {0.0, 0.0});
+  auto exclusion_box_z_param_ = this->declare_parameter<std::vector<double>>(
+    "exclude_within_z", {0.0, 0.0});
 
   if ((exclusion_box_x_param_[1] >= exclusion_box_x_param_[0]) &&
     (exclusion_box_y_param_[1] >= exclusion_box_y_param_[0]) &&
@@ -89,9 +92,7 @@ PointCloudToLaserScanNode::PointCloudToLaserScanNode(const rclcpp::NodeOptions &
     exclusion_box_max_y_ = exclusion_box_y_param_[1];
     exclusion_box_min_z_ = exclusion_box_z_param_[0];
     exclusion_box_max_z_ = exclusion_box_z_param_[1];
-  }
-  else
-  {
+  } else {
     exclusion_box_min_x_ = 0.0;
     exclusion_box_max_x_ = 0.0;
     exclusion_box_min_y_ = 0.0;
@@ -226,9 +227,9 @@ void PointCloudToLaserScanNode::cloudCallback(
       (*iter_z > exclusion_box_min_z_ && *iter_z < exclusion_box_max_z_)) {
       RCLCPP_DEBUG(
         this->get_logger(),
-        "rejected for point (%f, %f, %f) being in the exclusion region x: (%f, %f) y: (%f, %f), z: (%f, %f)\n",
-        *iter_x, *iter_y, *iter_z, exclusion_box_min_x_, exclusion_box_max_x_, exclusion_box_min_y_,
-        exclusion_box_max_y_, exclusion_box_min_z_, exclusion_box_max_z_);
+        "rejected for point (%f, %f, %f) being in the exclusion region x: (%f, %f) y: (%f, %f)"
+        "z: (%f, %f)\n", *iter_x, *iter_y, *iter_z, exclusion_box_min_x_, exclusion_box_max_x_,
+        exclusion_box_min_y_, exclusion_box_max_y_, exclusion_box_min_z_, exclusion_box_max_z_);
       continue;
     }
 


### PR DESCRIPTION
I added some parameters to filter out the point cloud points within a bounding box centered on the point cloud origin (original or transformed into the target `target_frame`.

Default extension of such bounding box is 0, so that by default is not filtering out anything.

If this is approved, I would also open other PRs to port this modification to the other branches.