### PR TITLE
remove deprecation warnings

### DIFF
--- a/include/pointcloud_to_laserscan/laserscan_to_pointcloud_node.hpp
+++ b/include/pointcloud_to_laserscan/laserscan_to_pointcloud_node.hpp
@@ -46,7 +46,7 @@
 #include <string>
 #include <thread>
 
-#include "message_filters/subscriber.h"
+#include "message_filters/subscriber.hpp"
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/message_filter.h"
 #include "tf2_ros/transform_listener.h"

--- a/include/pointcloud_to_laserscan/pointcloud_to_laserscan_node.hpp
+++ b/include/pointcloud_to_laserscan/pointcloud_to_laserscan_node.hpp
@@ -46,7 +46,7 @@
 #include <string>
 #include <thread>
 
-#include "message_filters/subscriber.h"
+#include "message_filters/subscriber.hpp"
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/message_filter.h"
 #include "tf2_ros/transform_listener.h"

--- a/src/laserscan_to_pointcloud_node.cpp
+++ b/src/laserscan_to_pointcloud_node.cpp
@@ -111,7 +111,7 @@ void LaserScanToPointCloudNode::subscriptionListenerThreadLoop()
           "Got a subscriber to pointcloud, starting laserscan subscriber");
         rclcpp::SensorDataQoS qos;
         qos.keep_last(input_queue_size_);
-        sub_.subscribe(this, "scan_in", qos.get_rmw_qos_profile());
+        sub_.subscribe(this, "scan_in", qos);
       }
     } else if (sub_.getSubscriber()) {
       RCLCPP_INFO(

--- a/src/pointcloud_to_laserscan_node.cpp
+++ b/src/pointcloud_to_laserscan_node.cpp
@@ -120,7 +120,7 @@ void PointCloudToLaserScanNode::subscriptionListenerThreadLoop()
           "Got a subscriber to laserscan, starting pointcloud subscriber");
         rclcpp::SensorDataQoS qos;
         qos.keep_last(input_queue_size_);
-        sub_.subscribe(this, "cloud_in", qos.get_rmw_qos_profile());
+        sub_.subscribe(this, "cloud_in", qos);
       }
     } else if (sub_.getSubscriber()) {
       RCLCPP_INFO(


### PR DESCRIPTION
`"message_filters/subscriber.h"` was deprecated long time ago, and now it's removed on `rolling`

The `subscribe` call is already deprecated too


Debs are broken on `rolling` https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__pointcloud_to_laserscan__ubuntu_noble_amd64__binary/78/consoleFull

It requires a new release on `rolling` when this PR is merged